### PR TITLE
Implement ADS1299 driver skeleton

### DIFF
--- a/firmware/lpc845breakout_new_project_prueba/drivers/ADS1299_Driver.c
+++ b/firmware/lpc845breakout_new_project_prueba/drivers/ADS1299_Driver.c
@@ -1,16 +1,9 @@
-/*
- * ADS1299_Driver.c
- *
- *  Created on: 7 ago. 2025
- *      Author: Usuario
- */
-
 #include "ADS1299_Driver.h"
 #include "fsl_gpio.h"
 #include "fsl_iocon.h"
+#include "fsl_spi.h"
+#include "fsl_clock.h"
 #include "board.h"
-
-
 
 static inline void delay_ms(uint32_t ms)
 {
@@ -22,91 +15,125 @@ static inline void delay_us(uint32_t us)
     SDK_DelayAtLeastUs(us, SystemCoreClock);
 }
 
-void Drv_ADS1299_initialize(void)
+static uint8_t numChannels;
+static uint8_t defaultChannelSettings[6];
+static uint8_t channelSettings[8][6];
+static bool useInBias[8];
+static bool useSRB2[8];
+
+#define ADS1299_SPI_BASE     SPI0
+#define ADS1299_SPI_BAUDRATE 1000000U
+#define ADS1299_SPI_SSEL     kSPI_Ssel0Assert
+
+static void ADS1299_InitPins(void)
 {
-    ADS1299_InitPins();
-    ADS1299_initialize_ads();
-}
-
-void ADS1299_InitPins(void)
-{
-    // Variables para definir cada pin y puerto
-    uint32_t ads_drdy_port = ADS_DRDY_PORT;
-    uint32_t ads_drdy_pin = ADS_DRDY_PIN;
-
-    uint32_t ads_rst_port = ADS_RST_PORT;
-    uint32_t ads_rst_pin = ADS_RST_PIN;
-
-    uint32_t ads_start_port = ADS_START_PORT;
-    uint32_t ads_start_pin = ADS_START_PIN;
-
-    uint32_t board_ads_port = BOARD_ADS_PORT;
-    uint32_t board_ads_pin = BOARD_ADS_PIN;
-
-    // uint32_t slave_ads_port = SLAVE_ADS_PORT;
-    // uint32_t slave_ads_pin = SLAVE_ADS_PIN;
-
     gpio_pin_config_t input_config = {
         .pinDirection = kGPIO_DigitalInput,
-        .outputLogic = 0U
+        .outputLogic = 0U,
     };
 
-    gpio_pin_config_t output_config_high = {
+    gpio_pin_config_t output_high = {
         .pinDirection = kGPIO_DigitalOutput,
-        .outputLogic = 1U
+        .outputLogic = 1U,
     };
 
-    gpio_pin_config_t output_config_low = {
+    gpio_pin_config_t output_low = {
         .pinDirection = kGPIO_DigitalOutput,
-        .outputLogic = 0U
+        .outputLogic = 0U,
     };
 
-    // Inicializar puertos GPIO necesarios
-    GPIO_PortInit(GPIO, ads_drdy_port);
-    GPIO_PortInit(GPIO, ads_rst_port);
-    GPIO_PortInit(GPIO, ads_start_port);
-    GPIO_PortInit(GPIO, board_ads_port);
+    GPIO_PortInit(GPIO, ADS_DRDY_PORT);
+    GPIO_PortInit(GPIO, ADS_RST_PORT);
+    GPIO_PortInit(GPIO, ADS_START_PORT);
+    GPIO_PortInit(GPIO, BOARD_ADS_PORT);
 
-    // --- BOARD ADS CHIP SELECT ---
-    GPIO_PinInit(GPIO, board_ads_port, board_ads_pin, &output_config_high);
-
-    /* // --- SLAVE ADS CHIP SELECT ---
-    GPIO_PinInit(GPIO, slave_ads_port, slave_ads_pin, &output_config_high);
-    */
-
-    // --- ADS RESET ---
-    GPIO_PinInit(GPIO, ads_rst_port, ads_rst_pin, &output_config_high);
-
-    // --- ADS START ---
-    GPIO_PinInit(GPIO, ads_start_port, ads_start_pin, &output_config_low);
-
-    // --- ADS DRDY (input) ---
-    GPIO_PinInit(GPIO, ads_drdy_port, ads_drdy_pin, &input_config);
+    GPIO_PinInit(GPIO, BOARD_ADS_PORT, BOARD_ADS_PIN, &output_high);
+    GPIO_PinInit(GPIO, ADS_RST_PORT, ADS_RST_PIN, &output_high);
+    GPIO_PinInit(GPIO, ADS_START_PORT, ADS_START_PIN, &output_low);
+    GPIO_PinInit(GPIO, ADS_DRDY_PORT, ADS_DRDY_PIN, &input_config);
 }
 
-void ADS1299_initialize_ads(void)
+static void ADS1299_InitSPI(void)
 {
-    // Delay inicial
+    spi_master_config_t spiConfig;
+    SPI_MasterGetDefaultConfig(&spiConfig);
+    spiConfig.baudRate_Bps = ADS1299_SPI_BAUDRATE;
+    spiConfig.sselNumber = ADS1299_SPI_SSEL;
+    SPI_MasterInit(ADS1299_SPI_BASE, &spiConfig, CLOCK_GetFreq(kCLOCK_MainClk));
+}
+
+static inline void ADS1299_csLow(void)
+{
+    GPIO_PinWrite(GPIO, BOARD_ADS_PORT, BOARD_ADS_PIN, 0U);
+}
+
+static inline void ADS1299_csHigh(void)
+{
+    GPIO_PinWrite(GPIO, BOARD_ADS_PORT, BOARD_ADS_PIN, 1U);
+}
+
+static uint8_t ADS1299_xfer(uint8_t data)
+{
+    uint8_t rx = 0U;
+    spi_transfer_t xfer = {0};
+    xfer.txData = &data;
+    xfer.rxData = &rx;
+    xfer.dataSize = 1;
+    xfer.configFlags = kSPI_EndOfTransfer;
+    SPI_MasterTransferBlocking(ADS1299_SPI_BASE, &xfer);
+    return rx;
+}
+
+static void ADS1299_SDATAC(void)
+{
+    ADS1299_csLow();
+    ADS1299_xfer(_SDATAC);
+    ADS1299_csHigh();
+    delay_us(3);
+}
+
+void ADS1299_Reset(void)
+{
+    ADS1299_csLow();
+    ADS1299_xfer(_RESET);
+    ADS1299_csHigh();
+    delay_us(12);
+    ADS1299_SDATAC();
+}
+
+void ADS1299_WriteDefaultChannelSettings(void)
+{
+    for (uint8_t ch = 1; ch <= numChannels; ++ch)
+    {
+        uint8_t value = 0;
+        value |= (channelSettings[ch - 1][POWER_DOWN] & 0x01U) << 7;
+        value |= channelSettings[ch - 1][GAIN_SET] & 0x70U;
+        if (channelSettings[ch - 1][SRB2_SET] == YES)
+        {
+            value |= 0x08U;
+        }
+        value |= channelSettings[ch - 1][INPUT_TYPE_SET] & 0x07U;
+
+        ADS1299_WriteRegister(CH1SET + (ch - 1), value);
+    }
+}
+
+void ADS1299_Init(void)
+{
+    ADS1299_InitPins();
+    ADS1299_InitSPI();
+
     delay_ms(50);
 
-    // Reset sequence: LOW -> HIGH
-    GPIO_PinWrite(GPIO, ADS_RST_PORT, ADS_RST_PIN, 0); // set LOW: reset pin
-    delay_us(4); // toggle reset pin
-    GPIO_PinWrite(GPIO, ADS_RST_PORT, ADS_RST_PIN, 1); // set HIGH
-    delay_us(20); // wait 18 Tclk before using device (aprox. 8uS)
+    GPIO_PinWrite(GPIO, ADS_RST_PORT, ADS_RST_PIN, 0U);
+    delay_us(4);
+    GPIO_PinWrite(GPIO, ADS_RST_PORT, ADS_RST_PIN, 1U);
+    delay_us(20);
 
-    // Reset del ADS único
-    ADS1299_resetADS(); // reset the ADS registers and stop DataContinousMode
+    ADS1299_Reset();
     delay_ms(20);
 
-    // Configurar el ADS único - sin salida de clock ya que no hay slave
-    ADS1299_WREG(CONFIG1, 0x90 | SAMPLE_RATE_2kHZ); // Turn off clk output (no slave present)
-    ADS1299_WREG(LOFF, 0x02);
-
-    // Solo un ADS = 8 canales
     numChannels = 8;
-
-    // DEFAULT CHANNEL SETTINGS FOR ADS
     defaultChannelSettings[POWER_DOWN] = NO;
     defaultChannelSettings[GAIN_SET] = ADS_GAIN24;
     defaultChannelSettings[INPUT_TYPE_SET] = ADSINPUT_NORMAL;
@@ -114,113 +141,102 @@ void ADS1299_initialize_ads(void)
     defaultChannelSettings[SRB2_SET] = YES;
     defaultChannelSettings[SRB1_SET] = NO;
 
-    uint8_t i, j = 0;
-    for(i = 0; i < numChannels; i++)
+    for (uint8_t i = 0; i < numChannels; ++i)
     {
-        for(j = 0; j < 6; j++)
+        for (uint8_t j = 0; j < 6; ++j)
         {
             channelSettings[i][j] = defaultChannelSettings[j];
         }
-        useInBias[i] = TRUE;
-        useSRB2[i] = TRUE;
+        useInBias[i] = true;
+        useSRB2[i] = true;
     }
+
+    ADS1299_WriteDefaultChannelSettings();
+    ADS1299_WriteRegister(CONFIG1, 0x90 | SAMPLE_RATE_2kHZ);
+    ADS1299_WriteRegister(LOFF, 0x02);
 }
 
-
-// Funciones para control de Chip Select
-static inline void ADS1299_csLow(void)
-{
-    GPIO_PinWrite(GPIO, BOARD_ADS_PORT, BOARD_ADS_PIN, 0);
-}
-
-static inline void ADS1299_csHigh(void)
-{
-    GPIO_PinWrite(GPIO, BOARD_ADS_PORT, BOARD_ADS_PIN, 1);
-}
-
-/**
- * @brief SPI communication method
- * @param _data Byte to transfer
- * @return Byte received from SPI target
- */
-uint8_t ADS1299_xfer(uint8_t _data)
-{
-    uint8_t rxData = 0;
-
-    // Ejemplo usando la API de SPI del LPC845
-    // Ajusta según tu configuración de SPI específica
-    spi_transfer_t xfer = {0};
-    xfer.txData = &_data;
-    xfer.rxData = &rxData;
-    xfer.dataSize = 1;
-
-    // Asumiendo que tienes SPI configurado como SPI_MASTER_HANDLE
-    // SPI_MasterTransferBlocking(SPI_MASTER_BASEADDR, &xfer);
-
-    // O si tienes una función más simple como en tu código original:
-    // rxData = spi_rw(_data);
-
-    return rxData;
-}
-
-/**
- * @brief Set all register values to default
- */
-void ADS1299_RESET(void)
+void ADS1299_Start(void)
 {
     ADS1299_csLow();
-    ADS1299_xfer(_RESET);
-
-    delay_us(10); // After serial communication, wait 4 or more tCLK cycles before taking CS high
+    ADS1299_xfer(_START);
     ADS1299_csHigh();
-    delay_us(12); // Must wait 18 tCLK cycles to execute this command (see Datasheet, pag 35)
 }
 
-/**
- * @brief Reset all the ADS1299 settings. Stops all data acquisition
- */
-void ADS1299_resetADS(void)
+void ADS1299_Stop(void)
 {
-    // Send RESET command to default all registers
-    ADS1299_RESET();
+    ADS1299_csLow();
+    ADS1299_xfer(_STOP);
+    ADS1299_csHigh();
+}
 
-    // Exit Read Data Continuous mode to communicate with ADS
-    ADS1299_SDATAC();
-    delay_ms(100);
+uint8_t ADS1299_ReadRegister(uint8_t reg)
+{
+    uint8_t value;
+    ADS1299_csLow();
+    ADS1299_xfer(_RREG | reg);
+    ADS1299_xfer(0x00);
+    value = ADS1299_xfer(0x00);
+    ADS1299_csHigh();
+    delay_us(2);
+    return value;
+}
 
-    // Turn off all channels (solo un ADS = canales 1-8)
-    for(uint8_t chan = 1; chan <= 8; chan++)
+void ADS1299_WriteRegister(uint8_t reg, uint8_t value)
+{
+    ADS1299_csLow();
+    ADS1299_xfer(_WREG | reg);
+    ADS1299_xfer(0x00);
+    ADS1299_xfer(value);
+    ADS1299_csHigh();
+    delay_us(2);
+}
+
+bool ADS1299_IsDataReady(void)
+{
+    return GPIO_PinRead(GPIO, ADS_DRDY_PORT, ADS_DRDY_PIN) == 0U;
+}
+
+void ADS1299_ReadData(int32_t *channelData, uint32_t *status)
+{
+    uint8_t buffer[27];
+    ADS1299_csLow();
+    for (uint8_t i = 0; i < 27; ++i)
     {
-        ADS1299_deactivateChannel(chan);
+        buffer[i] = ADS1299_xfer(0x00);
+    }
+    ADS1299_csHigh();
+
+    if (status != NULL)
+    {
+        *status = ((uint32_t)buffer[0] << 16) |
+                  ((uint32_t)buffer[1] << 8) |
+                  buffer[2];
+    }
+
+    for (uint8_t ch = 0; ch < 8; ++ch)
+    {
+        uint32_t raw = ((uint32_t)buffer[3 + ch * 3] << 16) |
+                       ((uint32_t)buffer[4 + ch * 3] << 8) |
+                       buffer[5 + ch * 3];
+        if (raw & 0x800000U)
+        {
+            raw |= 0xFF000000U;
+        }
+        channelData[ch] = (int32_t)raw;
     }
 }
 
-/**
- * @brief Send SDATAC command (Stop Data Continuous mode)
- */
-void ADS1299_SDATAC(void)
+uint8_t ADS1299_GetDeviceID(void)
 {
-    ADS1299_csLow();
-    ADS1299_xfer(0x11); // SDATAC command
-    delay_us(10);
-    ADS1299_csHigh();
-    delay_us(12);
+    return ADS1299_ReadRegister(ID_REG);
 }
 
-/**
- * @brief Deactivate a specific channel
- * @param channel Channel number (1-8)
- */
-void ADS1299_deactivateChannel(uint8_t channel)
+void ADS1299_DeactivateChannel(uint8_t channel)
 {
-    if(channel < 1 || channel > 8) return; // Validación de canal
-
-    // Escribir en el registro CHnSET para desactivar el canal
-    // Registro CHnSET = 0x05 + (channel - 1)
-    uint8_t reg = 0x05 + (channel - 1);
-    uint8_t value = 0x81; // Power down = 1, Gain = 24, Input shorted
-
-    ADS1299_WREG(reg, value);
+    if (channel < 1U || channel > 8U)
+    {
+        return;
+    }
+    ADS1299_WriteRegister(CH1SET + (channel - 1U), 0x81U);
 }
-
-

--- a/firmware/lpc845breakout_new_project_prueba/drivers/ADS1299_Driver.h
+++ b/firmware/lpc845breakout_new_project_prueba/drivers/ADS1299_Driver.h
@@ -1,286 +1,75 @@
 /*
  * ADS1299_Driver.h
- *
- *  Created on: 7 ago. 2025
- *      Author: Usuario
+ * Driver for ADS1299 EEG front-end
  */
 
 #ifndef ADS1299_DRIVER_H_
 #define ADS1299_DRIVER_H_
 
-#include "fsl_common.h"
+#include <stdint.h>
+#include <stdbool.h>
 #include "ADS1299_Parameters.h"
-/**
- * @brief Configure pins connected to the ADS
- */
-void ADS1299_InitPins(void);
 
 /**
- * @brief Configure the ADS itself
+ * @brief Initialize GPIOs, SPI and the ADS1299 device.
  */
-void Drv_ADS1299_initialize();
+void ADS1299_Init(void);
 
 /**
- * @brief Hard Reset ADS and power up sequence
+ * @brief Start continuous conversions.
  */
-//void Drv_ADS1299_initialize_ads();
+void ADS1299_Start(void);
 
 /**
- * @brief Stop data acquisition
+ * @brief Stop continuous conversions.
  */
-//void Drv_ADS1299_stopStreaming();
+void ADS1299_Stop(void);
 
 /**
- * @brief Start data acquisition
+ * @brief Read a register from the ADS1299.
+ * @param reg Register address.
+ * @return Register value.
  */
-//void Drv_ADS1299_startStreaming();
+uint8_t ADS1299_ReadRegister(uint8_t reg);
 
 /**
- * @brief Start continuous data acquisition
+ * @brief Write a register in the ADS1299.
+ * @param reg Register address.
+ * @param value Byte to write.
  */
-void Drv_ADS1299_startADS();
+void ADS1299_WriteRegister(uint8_t reg, uint8_t value);
 
 /**
- * @brief Stop continuous data acquisition
+ * @brief Check if new data are available.
+ * @return true when DRDY is low.
  */
-void Drv_ADS1299_stopADS();
+bool ADS1299_IsDataReady(void);
 
 /**
- * @brief Get out of low power mode
- * @param targetSS SPI target to talk to: BOARD_ADS, SLAVE_ADS or BOTH_ADS
+ * @brief Read one sample from all channels.
+ * @param channelData Pointer to array of 8 int32_t where the channel data will be stored.
+ * @param status Optional pointer to store the 24-bit status word.
  */
-void Drv_ADS1299_WAKEUP(uint8_t targetSS);
+void ADS1299_ReadData(int32_t *channelData, uint32_t *status);
 
 /**
- * @brief Go into low power mode
- * @param targetSS SPI target to talk to: BOARD_ADS, SLAVE_ADS or BOTH_ADS
+ * @brief Read device ID.
+ * @return Value of ID register.
  */
-void Drv_ADS1299_STANDBY(uint8_t targetSS);
+uint8_t ADS1299_GetDeviceID(void);
 
 /**
- * @brief Set all register values to default
- * @param targetSS SPI target to talk to: BOARD_ADS, SLAVE_ADS or BOTH_ADS
+ * @brief Power down one channel.
+ * @param channel Channel number 1-8.
  */
-void Drv_ADS1299_RESET(uint8_t targetSS);
+void ADS1299_DeactivateChannel(uint8_t channel);
 
 /**
- * @brief Start data acquisition
- * @param targetSS SPI target to talk to: BOARD_ADS, SLAVE_ADS or BOTH_ADS
+ * @brief Write default channel configuration to device.
  */
-void Drv_ADS1299_START(uint8_t targetSS);
+void ADS1299_WriteDefaultChannelSettings(void);
 
-/**
- * @brief Stop data acquisition
- * @param targetSS SPI target to talk to: BOARD_ADS, SLAVE_ADS or BOTH_ADS
- */
-void Drv_ADS1299_STOP(uint8_t targetSS);
-
-/**
- * @brief Go into read data continuous mode
- * @param targetSS SPI target to talk to: BOARD_ADS, SLAVE_ADS or BOTH_ADS
- */
-void Drv_ADS1299_RDATAC(uint8_t targetSS);
-
-/**
- * @brief Get out of read data continuous mode
- * @param targetSS SPI target to talk to: BOARD_ADS, SLAVE_ADS or BOTH_ADS
- */
-//void Drv_ADS1299_SDATAC(uint8_t targetSS);
-
-/**
- * @brief Read data one-shot
- * @param targetSS SPI target to talk to: BOARD_ADS, SLAVE_ADS or BOTH_ADS
- */
-void Drv_ADS1299_RDATA(uint8_t targetSS);
-
-/**
- * @brief Read one ADS register
- * @param _address Register address to read
- * @param targetSS SPI target to talk to: BOARD_ADS, SLAVE_ADS or BOTH_ADS
- * @return Requested register value
- */
-uint8_t Drv_ADS1299_RREG(uint8_t _address, uint8_t targetSS);
-
-/**
- * @brief  Read multiple ADS registers
- * @param _address Register address to read
- * @param _numRegistersMinusOne Number of registers to read minus one
- * @param targetSS SPI target to talk to: BOARD_ADS, SLAVE_ADS or BOTH_ADS
- */
-//void Drv_ADS1299_RREGS(uint8_t _address, uint8_t _numRegistersMinusOne, uint8_t targetSS);
-
-/**
- * @brief Write one ADS register
- * @param _address Register address to write
- * @param _value Byte to write in register
- * @param targetSS SPI target to talk to: BOARD_ADS, SLAVE_ADS or BOTH_ADS
- */
-void Drv_ADS1299_WREG(uint8_t _address,uint8_t _value, uint8_t targetSS);
-
-/**
- * @brief Write multiple ADS registers
- * @param _address Register address to write
- * @param _numRegistersMinusOne Number of registers to write minus one
- * @param targetSS SPI target to talk to: BOARD_ADS, SLAVE_ADS or BOTH_ADS
- */
-//void Drv_ADS1299_WREGS(uint8_t _address, uint8_t _numRegistersMinusOne, uint8_t targetSS);
-
-/**
- * @brief SPI chip select method
- * @param SS SPI target to talk to: BOARD_ADS, SLAVE_ADS or BOTH_ADS
- */
-void Drv_ADS1299_csLow(uint8_t SS);
-
-/**
- * @brief SPI chip de-select
- * @param SS SPI target to talk to: BOARD_ADS, SLAVE_ADS or BOTH_ADS
- */
-void Drv_ADS1299_csHigh(uint8_t SS);
-
-/**
- * @brief SPI communication method
- * @param _data Byte to transfer
- * @return Byte received from SPI target
- */
-uint8_t Drv_ADS1299_xfer(uint8_t _data);
-
-/**
- * @brief Write settings of only one specific channel
- * @param N Number of the channel to set (1-16)
- */
-void Drv_ADS1299_writeOneChannelSettings(uint8_t N);
-
-/**
- * @brief Write settings of all channels
- */
-void Drv_ADS1299_writeAllChannelSettings();
-
-/**
- * @brief Set all channels with the default values
- */
-void Drv_ADS1299_setChannelsToDefault();
-
-/**
- * @brief Activate specific channel N
- * @param N Number of the channel to activate (1-16)
- */
-void Drv_ADS1299_activateChannel(uint8_t N);
-
-/**
- * @brief De-activate specific channel N
- * @param N Number of the channel to de-activate (1-16)
- */
-void Drv_ADS1299_deactivateChannel(uint8_t N);
-
-/**
- * @brief Constrains a number to be within a range.
- * @param num Number to constrain
- * @param min Lower limit
- * @param max Upper limit
- * @return New number between the limits
- */
-uint8_t Drv_ADS1299_constrain(uint8_t num, uint8_t min, uint8_t max);
-
-/**
- * @brief Query to see if data is available from the ADS1299
- * @return TRUE is data is available, FALSE otherwise
- */
-bool Drv_ADS1299_isDataAvailable();
-
-/**
- * @brief Return the ID of the AFE device
- * @param targetSS SPI target to talk to: BOARD_ADS, SLAVE_ADS or BOTH_ADS
- * @return ID of the AFE device
- */
-uint8_t Drv_ADS1299_getDeviceID(uint8_t targetSS);
-
-/**
- * @brief Function called to receive new data from the ADS1299
- */
-void Drv_ADS1299_updateChannelData();
-
-/**
- * @brief Function called to receive new data from the master board
- */
-void Drv_ADS1299_updateBoardData();
-
- /**
- * @brief Function called to receive new data from the slave board
- */
-void Drv_ADS1299_updateSlaveData();
-
-/**
- * @brief Configure the test signals that can be inernally generated by the ADS1299
- * @param amplitudCode Amplitude of the test signal: ADSTESTSIG_NOCHANGE, ADSTESTSIG_AMP_1X, ADSTESTSIG_AMP_2X
- * @param freqCode Frequence of the test signal: ADSTESTSIG_NOCHANGE, ADSTESTSIG_PULSE_SLOW, ADSTESTSIG_PULSE_FAST
- */
-void Drv_ADS1299_configureInternalTestSignal(uint8_t amplitudeCode, uint8_t freqCode);
-
-/**
- * @brief Change the source of signal connected to the inputs of the ADS1299
- * @param inputCode Input types
- */
-void Drv_ADS1299_changeInputType(uint8_t inputCode);
-
-/**
- * @brief Return a array with ADS1299 registers data
- * @param *regArray Pointer to an array with 24 elements to store ADS registers values
- */
-void Drv_ADS1299_getRegistersData(uint8_t *regArray);
-
-/**
- * @brief To know if the Slave Board is present
- * @return HIGH if Slave Board is present, LOW if not
- */
-bool Drv_ADS1299_getSlavePresent();
-
-/**
- * @brief Return an array with the 6 values of default channel settings
- * @param *defChanSettings Pointer to an array with 6 elements to store Default Channel Settings
- */
-void Drv_ADS1299_getDefaultChannelSettings(uint8_t *defChanSettings);
-
-/**
- * @brief Change the lead off detect settings for specified channel
- * @param N Number of the channel to de-activate (1-16)
- */
-void Drv_ADS1299_changeOneChannelLeadOffDetect(uint8_t N);
-
-/**
- * @brief Change the lead off detect settings for all channels
- */
-void Drv_ADS1299_changeAllChannelLeadOffDetect();
-
-/**
- * @brief Check if Slave Board is present
- * @return HIGH if Slave board is present, LOW if not
- */
-bool Drv_ADS1299_smellSlave();
-
-/**
- * @brief Stop Slave ADS and remove link
- */
-void Drv_ADS1299_removeSlave();
-
-/**
- * @brief Configure CLK output and detect Slave board
- */
-void Drv_ADS1299_attachSlave();
-
-/**
- * @brief Reset all the ADS1299 settings. Stops all data acquisition
- * @param targetSS SPI target to talk to: BOARD_ADS, SLAVE_ADS or BOTH_ADS
- */
-void Drv_ADS1299_resetADS(uint8_t targetSS);
-
-/**
- * @brief Function to get Channel Data
- * @param &sampleCnt Pointer to a uint8_t variable to store Sample Count
- * @param *data Pointer to an array with 48 elements (24 of Mastar board data and 24 of Slave board data)
- */
-void Drv_ADS1299_getChannelData(uint8_t *sampleCnt, uint8_t *data);
-
-
-
+/* Compatibility wrapper for existing code */
+static inline void Drv_ADS1299_initialize(void) { ADS1299_Init(); }
 
 #endif /* ADS1299_DRIVER_H_ */


### PR DESCRIPTION
## Summary
- add new ADS1299 driver and header for single-chip setup
- provide basic init, register access, and data read helpers

## Testing
- `gcc -c drivers/ADS1299_Driver.c -I drivers -I board -I source -I CMSIS -I device -I component` *(fails: No valid CPU defined)*

------
https://chatgpt.com/codex/tasks/task_e_689a51bfa7b0832d895b7d3463ca43ac